### PR TITLE
Re-execute block based on transaction response code

### DIFF
--- a/p2p/pex/file.go
+++ b/p2p/pex/file.go
@@ -10,9 +10,9 @@ import (
 
 /* Loading & Saving */
 
-type addrBookJSON struct {
+type AddrBookJSON struct {
 	Key   string          `json:"key"`
-	Addrs []*knownAddress `json:"addrs"`
+	Addrs []*KnownAddress `json:"addrs"`
 }
 
 func (a *addrBook) saveToFile(filePath string) {
@@ -21,11 +21,11 @@ func (a *addrBook) saveToFile(filePath string) {
 
 	a.Logger.Info("Saving AddrBook to file", "size", a.size())
 
-	addrs := make([]*knownAddress, 0, len(a.addrLookup))
+	addrs := make([]*KnownAddress, 0, len(a.addrLookup))
 	for _, ka := range a.addrLookup {
 		addrs = append(addrs, ka)
 	}
-	aJSON := &addrBookJSON{
+	aJSON := &AddrBookJSON{
 		Key:   a.key,
 		Addrs: addrs,
 	}
@@ -50,13 +50,13 @@ func (a *addrBook) loadFromFile(filePath string) bool {
 		return false
 	}
 
-	// Load addrBookJSON{}
+	// Load AddrBookJSON{}
 	r, err := os.Open(filePath)
 	if err != nil {
 		panic(fmt.Sprintf("Error opening file %s: %v", filePath, err))
 	}
 	defer r.Close() // nolint: errcheck
-	aJSON := &addrBookJSON{}
+	aJSON := &AddrBookJSON{}
 	dec := json.NewDecoder(r)
 	err = dec.Decode(aJSON)
 	if err != nil {

--- a/p2p/pex/known_address.go
+++ b/p2p/pex/known_address.go
@@ -6,9 +6,9 @@ import (
 	"github.com/tendermint/tendermint/p2p"
 )
 
-// knownAddress tracks information about a known network address
+// KnownAddress tracks information about a known network address
 // that is used to determine how viable an address is.
-type knownAddress struct {
+type KnownAddress struct {
 	Addr        *p2p.NetAddress `json:"addr"`
 	Src         *p2p.NetAddress `json:"src"`
 	Buckets     []int           `json:"buckets"`
@@ -18,8 +18,8 @@ type knownAddress struct {
 	LastSuccess time.Time       `json:"last_success"`
 }
 
-func newKnownAddress(addr *p2p.NetAddress, src *p2p.NetAddress) *knownAddress {
-	return &knownAddress{
+func newKnownAddress(addr *p2p.NetAddress, src *p2p.NetAddress) *KnownAddress {
+	return &KnownAddress{
 		Addr:        addr,
 		Src:         src,
 		Attempts:    0,
@@ -29,32 +29,32 @@ func newKnownAddress(addr *p2p.NetAddress, src *p2p.NetAddress) *knownAddress {
 	}
 }
 
-func (ka *knownAddress) ID() p2p.ID {
+func (ka *KnownAddress) ID() p2p.ID {
 	return ka.Addr.ID
 }
 
-func (ka *knownAddress) isOld() bool {
+func (ka *KnownAddress) isOld() bool {
 	return ka.BucketType == bucketTypeOld
 }
 
-func (ka *knownAddress) isNew() bool {
+func (ka *KnownAddress) isNew() bool {
 	return ka.BucketType == bucketTypeNew
 }
 
-func (ka *knownAddress) markAttempt() {
+func (ka *KnownAddress) markAttempt() {
 	now := time.Now()
 	ka.LastAttempt = now
 	ka.Attempts++
 }
 
-func (ka *knownAddress) markGood() {
+func (ka *KnownAddress) markGood() {
 	now := time.Now()
 	ka.LastAttempt = now
 	ka.Attempts = 0
 	ka.LastSuccess = now
 }
 
-func (ka *knownAddress) addBucketRef(bucketIdx int) int {
+func (ka *KnownAddress) addBucketRef(bucketIdx int) int {
 	for _, bucket := range ka.Buckets {
 		if bucket == bucketIdx {
 			// TODO refactor to return error?
@@ -66,7 +66,7 @@ func (ka *knownAddress) addBucketRef(bucketIdx int) int {
 	return len(ka.Buckets)
 }
 
-func (ka *knownAddress) removeBucketRef(bucketIdx int) int {
+func (ka *KnownAddress) removeBucketRef(bucketIdx int) int {
 	buckets := []int{}
 	for _, bucket := range ka.Buckets {
 		if bucket != bucketIdx {
@@ -95,7 +95,7 @@ func (ka *knownAddress) removeBucketRef(bucketIdx int) int {
    worth keeping hold of.
 
 */
-func (ka *knownAddress) isBad() bool {
+func (ka *KnownAddress) isBad() bool {
 	// Is Old --> good
 	if ka.BucketType == bucketTypeOld {
 		return false

--- a/state/errors.go
+++ b/state/errors.go
@@ -2,6 +2,11 @@ package state
 
 import "fmt"
 
+// ErrCodeReExecBlock describes a code for instructing the re-execution of a
+// block. The ABCI app can return this code as a transaction execution response
+// code to force the execution of the containing block.
+const ErrCodeReExecBlock = uint32(10)
+
 type (
 	ErrInvalidBlock error
 	ErrProxyAppConn error

--- a/state/execution.go
+++ b/state/execution.go
@@ -13,10 +13,7 @@ import (
 	dbm "github.com/tendermint/tm-db"
 )
 
-// ErrCodeReExecBlock describes a code for instructing the re-execution of a
-// block. The ABCI app can return this code as a transaction execution response
-// code to force the execution of the containing block.
-const ErrCodeReExecBlock = uint32(10)
+
 
 //-----------------------------------------------------------------------------
 // BlockExecutor handles block execution and state updates.


### PR DESCRIPTION
This update allows a block to be re-executed whenever a specific error code of a transaction's response is returned.